### PR TITLE
Múltiplos nomes e pontuação negativa

### DIFF
--- a/assets/input/chat_example.txt
+++ b/assets/input/chat_example.txt
@@ -1,14 +1,14 @@
 08/05/2023 17:02 - Chico: Andando pela bela UnB
-09/05/2023 17:02 - Chico: chico +2 #NOE detonando hoje
-10/05/2023 17:02 - Abigail: +2 #NDP
+09/05/2023 17:02 - Chico: chico +4 #NOE detonando hoje
+10/05/2023 17:02 - Abigail: +2 #ndp
 10/05/2023 17:02 - Zeca: +2 #NUT
 10/05/2023 10:32 - Zeca: <Arquivo de mídia oculto>
 10/05/2023 17:02 - Chico: #BOPE +40
-10/05/2023 17:02 - Chico: Chico +2 #NOE
+10/05/2023 17:02 - Chico: Chico -2 #Noe
 11/05/2023 17:02 - Chico: +2 #NOE Chico Buarque
 11/05/2023 10:33 - Zeca: To com fome mano, que merda
 11/05/2023 10:33 - Zeca: VAMO NUT!
 11/05/2023 17:02 - Chico: Fodasse mano
 11/05/2023 17:02 - Chico: NOE no topo!
 11/05/2023 17:02 - Chico: Br comer uma lasanha braba
-11/05/2023 17:02 - Chico: #NUT zeca +2
+11/05/2023 17:02 - Chico: #nut zeca +2

--- a/assets/input/chat_example.txt
+++ b/assets/input/chat_example.txt
@@ -11,4 +11,6 @@
 11/05/2023 17:02 - Chico: Fodasse mano
 11/05/2023 17:02 - Chico: NOE no topo!
 11/05/2023 17:02 - Chico: Br comer uma lasanha braba
-11/05/2023 17:02 - Chico: #nut zeca +2
+11/05/2023 17:02 - Zeca: +6 #noe Zeca, André Silva, Carlos
+11/05/2023 17:03 - Zeca: Zeca +2 #noe, tentei, mas não consegui
+11/05/2023 18:10 - Zeca: +2 #nut Rafa, tava difícil hoje

--- a/src/counter.py
+++ b/src/counter.py
@@ -4,6 +4,9 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Tuple
 from argparse import ArgumentParser
 
+sector_pattern = re.compile(r'#(noe|nip|nut|bope|ndp|trainees)', re.IGNORECASE)
+points_pattern = re.compile(r'([\+|\-]\d+)')
+
 
 def extract_messages_of_week(input_file_path: str, start_date: datetime, end_date: datetime):
     """
@@ -27,10 +30,8 @@ def extract_messages_of_week(input_file_path: str, start_date: datetime, end_dat
 
 
 def get_name_from_message(message_text: str):
-
-    message_without_points = re.sub(r'\+(\d+)', '', message_text)  # removes +4
-    cleaned_message = re.sub(
-        r'#(\w{3,4})', '', message_without_points).strip()  # removes #noe
+    message_without_sector = sector_pattern.sub('', message_text)  # removes #noe
+    cleaned_message = points_pattern.sub('', message_without_sector).strip()  # removes +2
 
     # Se só tiver uma palavra, essa palavra é o nome
     message_words = cleaned_message.split(' ')
@@ -56,12 +57,11 @@ def create_dict_sector2points(messages: List) -> Tuple[Dict, Dict]:
     for message in messages:
 
         # Pega o corpo da mensagem (que inicia depois dos dois pontos)
-        # message_text = '10/05/2023 17:02 - Chico: Chico +2 #NOE'
+        # message = '10/05/2023 17:02 - Chico: Chico +2 #NOE'
         message_text = "".join(message.split(':')[2:]).strip()
 
-        sector_match = re.search(
-            r'#(\w{3,4})', message_text)  # ex: #nip, #bope
-        points_match = re.search(r'\+(\d+)', message_text)  # ex: +2, +10
+        sector_match = sector_pattern.search(message_text)  # ex: #noe
+        points_match = points_pattern.search(message_text)  # ex: +2, -10
 
         if sector_match and points_match:
             sector = sector_match.group(1).lower()
@@ -92,12 +92,12 @@ def create_dict_sector2points(messages: List) -> Tuple[Dict, Dict]:
 def save_results_file(sector_and_points: Dict, name_and_points, output_directory_path: str, start_date: datetime,
                       end_date: datetime):
     sector_and_points_sorted_by_points = dict(sorted(sector_and_points.items(),
-                                                   key=lambda item: item[1],
-                                                   reverse=True))
+                                                     key=lambda item: item[1],
+                                                     reverse=True))
 
     name_and_points_sorted_by_points = dict(sorted(name_and_points.items(),
-                                                 key=lambda item: item[1],
-                                                 reverse=True))
+                                                   key=lambda item: item[1],
+                                                   reverse=True))
 
     output_file_path = path.join(output_directory_path, 'results.txt')
 

--- a/src/counter.py
+++ b/src/counter.py
@@ -4,9 +4,6 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Tuple
 from argparse import ArgumentParser
 
-sector_pattern = re.compile(r'#(noe|nip|nut|bope|ndp|trainees)', re.IGNORECASE)
-points_pattern = re.compile(r'([\+|\-]\d+)')
-
 
 def extract_messages_of_week(input_file_path: str, start_date: datetime, end_date: datetime):
     """
@@ -92,6 +89,9 @@ def assign_points(sector_and_points: Dict, name_and_points: Dict, message: str, 
 def create_dict_sector2points(messages: List) -> Tuple[Dict, Dict]:
     sector_and_points = {}
     name_and_points = {}
+
+    sector_pattern = re.compile(r'#(noe|nip|nut|bope|ndp|trainees)', re.IGNORECASE)
+    points_pattern = re.compile(r'([\+|\-]\d+)') # ex: +2, -10
 
     for message in messages:
 

--- a/src/counter.py
+++ b/src/counter.py
@@ -28,26 +28,65 @@ def extract_messages_of_week(input_file_path: str, start_date: datetime, end_dat
 
     return messages
 
+def get_capitalized_name(message_text: str):
+    capitalized_words = re.findall(
+            r'\b[A-Z][^A-Z ]+\b', message_text)  # ex: Chico Buarque
+    name = ' '.join(capitalized_words)
+
+    return name
 
 def get_name_from_message(message_text: str):
-    message_without_sector = sector_pattern.sub('', message_text)  # removes #noe
-    cleaned_message = points_pattern.sub('', message_without_sector).strip()  # removes +2
-
     # Se só tiver uma palavra, essa palavra é o nome
-    message_words = cleaned_message.split(' ')
+    message_words = message_text.split(' ')
     if len(message_words) == 1:
         name = message_words[0]
     else:
         # Se tiver mais de uma palavra, pega as palavras que começam com letra maiúscula e junta
-        capitalized_words = re.findall(
-            r'\b[A-Z][^A-Z ]+\b', cleaned_message)  # ex: Chico Buarque
-        name = ' '.join(capitalized_words)
-
+        name = get_capitalized_name(message_text)
         # Se tiver mais de uma palavra mas nenhuma começar com letra maiúscula, pega a primeira palavra
         if not name:
             name = message_words[0]
 
     return name.title()
+
+def get_names_from_message(message_text: str):
+    names = []
+    splitted_message = message_text.split(',')
+
+    for text in splitted_message:
+        name = get_capitalized_name(text)
+        if name:
+            names.append(name.title())
+
+    return names
+
+
+def assign_points(sector_and_points: Dict, name_and_points: Dict, message: str, message_text: str, sector: str, points: str):
+    names = []
+
+    # caso message_text possua sector e points mas não tenha nome, sector pontua mas a pessoa não.
+    # pontuação para o núcleo será considerada mas não será atribuída a nenhum jogador
+    if sector in sector_and_points:
+        sector_and_points[sector] += int(points)
+    else:
+        sector_and_points[sector] = int(points)
+
+    if ',' in message_text:
+        names = get_names_from_message(message_text)
+        points = int(points) // len(names)
+    else:
+        name = get_name_from_message(message_text)
+        if name:
+            names.append(name)
+
+    if not names:
+        print(f'Mensagem sem nome: {message}')
+
+    for name in names:
+        if name in name_and_points:
+            name_and_points[name] += int(points)
+        else:
+            name_and_points[name] = int(points)
 
 
 def create_dict_sector2points(messages: List) -> Tuple[Dict, Dict]:
@@ -64,25 +103,13 @@ def create_dict_sector2points(messages: List) -> Tuple[Dict, Dict]:
         points_match = points_pattern.search(message_text)  # ex: +2, -10
 
         if sector_match and points_match:
+            message_without_sector = sector_pattern.sub('', message_text)  # removes #noe
+            cleaned_message = points_pattern.sub('', message_without_sector).strip()  # removes +2
+
             sector = sector_match.group(1).lower()
             points = points_match.group(1)
 
-            if sector in sector_and_points:
-                sector_and_points[sector] += int(points)
-
-            else:
-                sector_and_points[sector] = int(points)
-
-            # caso message_text possua sector e points mas não tenha nome, sector pontua mas a pessoa não.
-            # pontuação para o núcleo será considerada mas não será atribuída a nenhum jogador
-            name = get_name_from_message(message_text)
-            if name:
-                if name in name_and_points:
-                    name_and_points[name] += int(points)
-                else:
-                    name_and_points[name] = int(points)
-            else:
-                print(f'Mensagem sem nome: {message}')
+            assign_points(sector_and_points, name_and_points, message, cleaned_message, sector, points)
         else:
             continue
 


### PR DESCRIPTION
- Permite pontuações negativas. Bom para correção de erros e moderação.
- Muda a regex de identificação do núcleo para que identifique-o a partir de uma lista predeterminada de palavras. A motivação principal disso foi adicionar o núcleo "trainees". O Pejão comentou comigo que eles tão planejando incluir os trainees, então já adiantei (mas não tenho certeza).
- Permite atribuir pontos para várias pessoas em uma mesma mensagem, com os nomes separados por vírgula. A pontuação é dividida igualmente entre os participantes.

**Obs:**

Quando estava fazendo essa feature, encontrei um desafio. Tome como exemplos as seguintes mensagens:

João, André Silva, Carlos +12 #noe
João +3 #noe, tentei, mas não consegui

Ao limpar a mensagem e separar pelas vírgulas, ficamos com as seguintes listas:

```
["João", "André Silva", "Carlos"]
["João", "tentei", "mas não consegui"]
```

Como diferenciar o que é nome e o que não é? Pensei em duas abordagens:

1. Só considerar nome o que começar com letra maiúscula.
2. Assumir que as mensagens de pontos não terão textos extras além do nome (o que vai contra o que a gente fez até aqui).

Eu escolhi a opção 1, então quando forem mandar uma mensagem com múltiplos participantes (na vdd, qualquer mensagem que contenha vírgula), **terão que capitalizar os nomes**.
Queria saber qual abordagem você acha melhor. Uma coisa a se levar em consideração é que desde que foi implementado o focafit counter, a maioria (se não todas) as mensagens de pontuação só contém o nome, a pontuação e o núcleo, sem textos extras.